### PR TITLE
corrected iox xe netflow interface sampler syntax and sampler object syntax

### DIFF
--- a/Cisco/iOS-XE/netflow-9-interfaces.conf
+++ b/Cisco/iOS-XE/netflow-9-interfaces.conf
@@ -1,4 +1,4 @@
 ! needs to be added on each Layer3 interfaces for sampling
 interface <interface_name>
-    ip flow monitor <KENTIK-MONITOR> input <KENTIK_FLOW_SAMPLER>
+    ip flow monitor <KENTIK-MONITOR> sampler <KENTIK_FLOW_SAMPLER> input
     exit

--- a/Cisco/iOS-XE/netflow-9.conf
+++ b/Cisco/iOS-XE/netflow-9.conf
@@ -18,7 +18,7 @@ flow record <CUSTOM-FLOW-RECORD>
     collect timestamp sys-uptime last
 !
 sampler <KENTIK_NETFLOW_SAMPLER>
-    mode 1 out-of {{device_sample_rate}}
+    mode random 1 out-of {{device_sample_rate}}
 !
 flow exporter <KENTIK-EXPORT>
     ! Direct erxport to Kentik Flow Ingest (without Flow Proxy)


### PR DESCRIPTION
This syntax is tested on xe, because I just added an XE customer to Kentik.

'random' comes directly after mode

sampler kentik-sampler
 mode random 1 out-of 1024

'sampler <sampler-name>' comes before input/output and after the flow monitor's name

 ip flow monitor kentik-flow-monitor sampler kentik-sampler input