### PR TITLE
Missing curly braces

### DIFF
--- a/Juniper/MX-series/ipfix.conf
+++ b/Juniper/MX-series/ipfix.conf
@@ -16,6 +16,7 @@ services {
       }
     }
   }
+}
 forwarding-options {
   sampling {
     instance {
@@ -49,3 +50,4 @@ forwarding-options {
       }
     }
   }
+}

--- a/Vyatta/bgp.conf
+++ b/Vyatta/bgp.conf
@@ -1,3 +1,4 @@
 # no BGP config snippet available for Vyatta router devices at this time
 # you are welcome to contribute yours on Kentik's config snippet public git repository:
 # https://github.com/kentik/config-snippets/blob/master/Vyatta/bgp.conf
+This is just a test.

--- a/Vyatta/bgp.conf
+++ b/Vyatta/bgp.conf
@@ -1,4 +1,3 @@
 # no BGP config snippet available for Vyatta router devices at this time
 # you are welcome to contribute yours on Kentik's config snippet public git repository:
 # https://github.com/kentik/config-snippets/blob/master/Vyatta/bgp.conf
-This is just a test.


### PR DESCRIPTION
Added a couple missing curly braces to the ends of the stanzas in the ipfix config for Juniper MX.