### PR TITLE
Update netflow-9-interfaces.conf

### DIFF
--- a/Cisco/IOS-XE/netflow-9-interfaces.conf
+++ b/Cisco/IOS-XE/netflow-9-interfaces.conf
@@ -1,4 +1,4 @@
 ! needs to be added on each Layer3 interfaces for sampling
 interface <interface_name>
-    ip flow monitor <KENTIK-MONITOR> sampler <KENTIK_FLOW_SAMPLER> input
+    ip flow monitor <KENTIK-MONITOR> sampler <KENTIK_NETFLOW_SAMPLER> input
     exit


### PR DESCRIPTION
Fixed a mis-match that was causing the sampler that is configured to not match what is applied on the interface.