### PR TITLE
Mwdean patch cisco ios xe xr bgp static route

### DIFF
--- a/Cisco/iOS-XE/bgp.conf
+++ b/Cisco/iOS-XE/bgp.conf
@@ -1,18 +1,48 @@
-! Do not send default route
-route-map <KENTIK_OUT> deny 15
+! Kentik Detect iBGP Session Config
+! IOS-XE
 !
-  match ip address 0.0.0.0/0
-  continue
-end
+! The outbound policy objects will exclude a default
+! route while allowing the rest of your active forwarding
+! table to be advertised. Explicit definitions can help
+! to clearly show prefixes being exchanged with peers.
+!
+! ***You can choose not to define an inbound policy
+!  on Cisco IOS-XE, due to the default deny behavior.***
+!
+!
+! List for matching any prefix.
+ip prefix-list any seq 5 permit 0.0.0.0/0 le 32
+!
+! List for easily sharing any/all but a default prefix.
+ip prefix-list any_but_default seq 5 deny 0.0.0.0/0
+ip prefix-list any_but_default seq 15 permit 0.0.0.0/0 le 32
+!
+!
+! Inbound BGP policy utilizing the 'any' list to
+! deny all inbound prefixes.
+route-map <KENTIK_IN> deny 15
+  match ip address prefix-list any
+!
+! Outbound BGP policy utilizing the 'any_but_default' list
+! in order to allow any prefix but your default route to advertise
+! to Kentik.
+route-map <KENTIK_OUT> permit 15
+  match ip address prefix-list any_but_default
 !
 router bgp {{kentik_portal_ASN}}
     neighbor {{kentik_UI_bgp_peering_ipv4}} remote-as {{kentik_portal_ASN}}
     neighbor {{kentik_UI_bgp_peering_ipv4}} description <KENTIK_DETECT_iBGP_route_reflector_client>
+    ! IP Address of this source interface needs to match what is in the admin portal
+    ! for this device.(***For multi-homed devices, best to use a public loopback interface***)
     neighbor {{kentik_UI_bgp_peering_ipv4}} update-source <BGP_source_interface_name>
 !
 address-family ipv4
     neighbor {{kentik_UI_bgp_peering_ipv4}} activate
+    ! Enables iBGP session to reflect routes to Kentik as a
+    ! RR server. Otherwise, since this is an iBGP session, received
+    ! routes would not be re-advertised.
     neighbor {{kentik_UI_bgp_peering_ipv4}} route-reflector-client
+    neighbor {{kentik_UI_bgp_peering_ipv4}} route-map <KENTIK_IN> in
     neighbor {{kentik_UI_bgp_peering_ipv4}} route-map <KENTIK_OUT> out
 ! Enable VPNv4 address family to send VRF routes to Kentik
 address-family ipv4

--- a/Cisco/iOS-XE/bgp.conf
+++ b/Cisco/iOS-XE/bgp.conf
@@ -1,6 +1,12 @@
 ! Kentik Detect iBGP Session Config
 ! IOS-XE
 !
+! Add a static route per Internet upstream for this Kentik (multi-hop BGP) peer.
+ip route {{kentik_UI_bgp_peering_ipv4}} 255.255.255.255 <Upstream_Transit_Interface-I> 50 name Kentik-Static-BGP-multihop
+!! If you have multiple internet upstreams, do one for as many as you have. !!
+ip route {{kentik_UI_bgp_peering_ipv4}} 255.255.255.255 <Upstream_Transit_Interface-II> 55 name Kentik-Static-BGP-multihop
+ip route {{kentik_UI_bgp_peering_ipv4}} 255.255.255.255 <Upstream_Transit_Interface-III> 60 name Kentik-Static-BGP-multihop
+!
 ! The outbound policy objects will exclude a default
 ! route while allowing the rest of your active forwarding
 ! table to be advertised. Explicit definitions can help
@@ -8,7 +14,6 @@
 !
 ! ***You can choose not to define an inbound policy
 !  on Cisco IOS-XE, due to the default deny behavior.***
-!
 !
 ! List for matching any prefix.
 ip prefix-list any seq 5 permit 0.0.0.0/0 le 32

--- a/Cisco/iOS-XR/bgp.conf
+++ b/Cisco/iOS-XR/bgp.conf
@@ -1,3 +1,12 @@
+! Kentik Detect iBGP Session Config
+! IOS-XR
+!
+! Add a static route per Internet upstream for this Kentik (multi-hop BGP) peer.
+router static address-family ipv4 unicast {{kentik_UI_bgp_peering_ipv4}}/32 <Upstream_Transit_Interface-I-Type> <Upstream_Transit_Interface-I-Number> 50 description Kentik-Static-BGP-multihop
+!! If you have multiple internet upstreams, do one for as many as you have. !!
+router static address-family ipv4 unicast {{kentik_UI_bgp_peering_ipv4}}/32 <Upstream_Transit_Interface-II-Type> <Upstream_Transit_Interface-II-Number> 50 description Kentik-Static-BGP-multihop
+router static address-family ipv4 unicast {{kentik_UI_bgp_peering_ipv4}}/32 <Upstream_Transit_Interface-III-Type> <Upstream_Transit_Interface-III-Number> 50 description Kentik-Static-BGP-multihop
+!
 neighbor {{kentik_UI_bgp_peering_ipv4}}
   remote-as {{kentik_portal_ASN}}
   timers 30 720


### PR DESCRIPTION
I added a static route entry for the Kentik BGP multi-hop peer per Internet upstream, so the peer is reachable. Added to both, XE and XR files.

-mwdean