### PR TITLE
consistency changes

### DIFF
--- a/Cisco/4500/netflow-9-agent.conf
+++ b/Cisco/4500/netflow-9-agent.conf
@@ -28,5 +28,4 @@ flow monitor <KENTIK-MONITOR>
     ! if using standard default Netflow records
     record netflow-original
     cache timeout active 60
-    cache timeout inactive 60
-    cache entries 1000
+    cache timeout inactive 15

--- a/Cisco/4500/netflow-9.conf
+++ b/Cisco/4500/netflow-9.conf
@@ -28,5 +28,4 @@ flow monitor <KENTIK-MONITOR>
     ! else using standard default Netflow records
     record netflow-original
     cache timeout active 60
-    cache timeout inactive 60
-    cache entries 1000
+    cache timeout inactive 15

--- a/Cisco/IOS-XR/netflow-9-agent.conf
+++ b/Cisco/IOS-XR/netflow-9-agent.conf
@@ -28,7 +28,7 @@ flow monitor-map <KENTIK_FLOW_MPLS_MONITOR>
  record mpls ipv4-ipv6-fields
  exporter <KENTIK_FLOW_EXPORTER>
  cache timeout active 60
- cache timeout inactive 5
+ cache timeout inactive 15
 !
 sampler-map <KENTIK_FLOW_SAMPLER>
   ! Set sample rate based on flow volume.

--- a/Cisco/IOS-XR/netflow-9.conf
+++ b/Cisco/IOS-XR/netflow-9.conf
@@ -28,7 +28,7 @@ flow monitor-map <KENTIK_FLOW_MPLS_MONITOR>
  record mpls ipv4-ipv6-fields
  exporter <KENTIK_FLOW_EXPORTER>
  cache timeout active 60
- cache timeout inactive 5
+ cache timeout inactive 15
 !
 sampler-map <KENTIK_FLOW_SAMPLER>
   ! Set sample rate based on flow volume.

--- a/Juniper/MX-series/ipfix-agent.conf
+++ b/Juniper/MX-series/ipfix-agent.conf
@@ -3,7 +3,7 @@ services {
     version-ipfix {
       template mpls-ipv4 {
         flow-active-timeout 60;
-        flow-inactive-timeout 10;
+        flow-inactive-timeout 15;
         template-refresh-rate {
           packets 30;
           seconds 60;
@@ -16,7 +16,7 @@ services {
       }      
       template ipv4 {
         flow-active-timeout 60;
-        flow-inactive-timeout 10;
+        flow-inactive-timeout 15;
         template-refresh-rate {
           packets 30;
           seconds 60;
@@ -29,7 +29,7 @@ services {
       }
       template ipv6 {
         flow-active-timeout 60;
-        flow-inactive-timeout 10;
+        flow-inactive-timeout 15;
         template-refresh-rate {
           packets 30;
           seconds 60;

--- a/Juniper/MX-series/ipfix.conf
+++ b/Juniper/MX-series/ipfix.conf
@@ -3,7 +3,7 @@ services {
     version-ipfix {
       template mpls-ipv4 {
         flow-active-timeout 60;
-        flow-inactive-timeout 10;
+        flow-inactive-timeout 15;
         template-refresh-rate {
           packets 30;
           seconds 60;
@@ -16,7 +16,7 @@ services {
       }      
       template ipv4 {
         flow-active-timeout 60;
-        flow-inactive-timeout 10;
+        flow-inactive-timeout 15;
         template-refresh-rate {
           packets 30;
           seconds 60;
@@ -29,7 +29,7 @@ services {
       }
       template ipv6 {
         flow-active-timeout 60;
-        flow-inactive-timeout 10;
+        flow-inactive-timeout 15;
         template-refresh-rate {
           packets 30;
           seconds 60;


### PR DESCRIPTION
inactive timeout consistency changes. 

also this template refresh seems really fast https://github.com/kentik/config-snippets/blob/e6f5e5e3aed5f7cf50cc4a29be4d160bc1c0087e/Juniper/MX-series/ipfix-agent.conf#L7-L9 should we make this slower? 

why doesn't this  have interfaces?  https://github.com/kentik/config-snippets/blob/e6f5e5e3aed5f7cf50cc4a29be4d160bc1c0087e/Cisco/Nexus-5000/netflow-9.conf#L22-L31

why doesn't this have interfaces? https://github.com/kentik/config-snippets/blob/e6f5e5e3aed5f7cf50cc4a29be4d160bc1c0087e/Cisco/Nexus-9000/netflow-9.conf#L3-L14
