### PR TITLE
Remove use-vrtr-if-index

### DIFF
--- a/Nokia/README.md
+++ b/Nokia/README.md
@@ -3,4 +3,3 @@ Details on how to use the below templates to configure a Timetra/Alcatel/Lucent/
 
 # Nokia configuration notes
 * Nokia/Alcaltel/Lucent routers will re-shuffle SNMP interface IDs upon rebook, to circumvent this issue, make sure to implement the config in [snmp.conf](https://github.com/kentik/config-snippets/blob/master/Nokia/snmp.conf)
-* Nokia/Alcatel/Lucent routers use an internal global IF index ID as the incoming and outgoing interface in their flow records. These are NOT the same SNMP ifIndex interface identifiers used in flow by most other devices. In order to use the SNMP ifIndex in the flow data so that Kentik can correlate this data with the SNMP IF-MIB table, the be sure to set "use-vrtr-if-index" under config -> clfowd More information can be found in Nokia's documentation (https://infocenter.nokia.com/public/7750SR140R4/topic/com.sr.router.config/html/cflowd_cli.html#tgardner5iexrn6muno)

--- a/Nokia/ipfix-agent.conf
+++ b/Nokia/ipfix-agent.conf
@@ -2,7 +2,6 @@ config>cflowd#
   active-timeout 1 # minutes
   inactive-timeout 60 # seconds
   template-retransmit 60 # seconds
-  use-vrtr-if-index
   rate {{device_sample_rate}}
   collector {{kentik_flow_proxy_agent_IP}}:{{pfix_port_default_9995_with_agent}} version 10
     template-set mpls-ip

--- a/Nokia/ipfix.conf
+++ b/Nokia/ipfix.conf
@@ -2,7 +2,6 @@ config>cflowd#
   active-timeout 1 # minutes
   inactive-timeout 60 # seconds
   template-retransmit 60 # seconds
-  use-vrtr-if-index
   rate {{device_sample_rate}}
   collector {{kentik_ingest_ip_from_UI}}:{{kentik_ingest_UDP_port_from_UI}} version 10
     template-set mpls-ip


### PR DESCRIPTION
Removing use-vrtr-if-index recommendation based on our recent Timetra MIB updates since this now breaks things.