### PR TITLE
Cisco IOS XR Streaming Telemetry source-interface command

### DIFF
--- a/Cisco/IOS-XR/telemetry_dialout-agent.conf
+++ b/Cisco/IOS-XR/telemetry_dialout-agent.conf
@@ -11,5 +11,7 @@ telemetry model-driven
  subscription <KENTIK-SUBSCRIPTION>
   sensor-group-id <KENTIK-SENSOR-GROUP> sample-interval 30000
   destination-id <KENTIK-DESTINATION>
+  ! Name of interface whose IP will be source of telemetry stream (same as used for flows)
+  source-interface <source_interface_name>
  !
 !

--- a/Cisco/IOS-XR/telemetry_dialout.conf
+++ b/Cisco/IOS-XR/telemetry_dialout.conf
@@ -11,5 +11,7 @@ telemetry model-driven
  subscription <KENTIK-SUBSCRIPTION>
   sensor-group-id <KENTIK-SENSOR-GROUP> sample-interval 30000
   destination-id <KENTIK-DESTINATION>
+  ! Name of interface whose IP will be source of telemetry stream (same as used for flows)
+  source-interface <source_interface_name>
  !
 !


### PR DESCRIPTION
Cisco IOS XR Streaming Telemetry source-interface command added as it is required that the source IP address matches the same source IP which we have in the portal which is used for sending flows.