### PR TITLE
Update ipfix-mpls.conf

### DIFF
--- a/Juniper/MX-series/ipfix-mpls.conf
+++ b/Juniper/MX-series/ipfix-mpls.conf
@@ -26,6 +26,9 @@ services {
             template mpls-ipv4 {
                 flow-active-timeout 60;
                 flow-inactive-timeout 10;
+                nexthop-learning {
+                    enable;
+                 }
                 template-refresh-rate {
                     packets 30;
                     seconds 60;


### PR DESCRIPTION
Adding nexthop-learning enable to this, as this fixes an issue that is documented in https://www.juniper.net/documentation/us/en/software/junos/flow-monitoring/topics/ref/statement/nexthop-learning-edit-services-flow-monitoring.html, where the Outbound Interface ID will be set to 0 unless enabled. I verified that this resolves an issue where the destination interface was being set to 0 until we added this to the configuration on an MX240.