### PR TITLE
fixing our recommended kproxy port for streaming telemetry

### DIFF
--- a/Cisco/IOS-XR/telemetry_dialout-agent.conf
+++ b/Cisco/IOS-XR/telemetry_dialout-agent.conf
@@ -1,6 +1,6 @@
 telemetry model-driven
  destination-group <KENTIK-DESTINATION>
-  address-family ipv4 <kentik_flow_proxy_agent_IP> port <netflow-9_port_default_9995_with_agent>
+  address-family ipv4 <kentik_flow_proxy_agent_IP> port <netflow-9_port_default_9555_with_agent>
    encoding self-describing-gpb
    protocol tcp
   !

--- a/Juniper/MX-series/telemetry_native-agent.conf
+++ b/Juniper/MX-series/telemetry_native-agent.conf
@@ -5,7 +5,7 @@ services {
             # remote-address - IP of the Kentik Flow Proxy Agent
             remote-address <kentik_flow_proxy_agent_IP>;
             # remote-port - port of the Kentik Flow Proxy Agent
-            remote-port <ipfix_port_default_9995_with_agent>;
+            remote-port <ipfix_port_default_9555_with_agent>;
         }
         export-profile KENTIK-PROF {
             # IP of interface that will be source of telemety records.


### PR DESCRIPTION
according to https://kb.kentik.com/v0/Bd04.htm#Bd04-kproxy_for_Streaming_Telemetry we should be setting the port to 9555