### PR TITLE
Add gNMI ST configs for Juniper

### DIFF
--- a/Juniper/MX-series/telemetry_gnmi.conf
+++ b/Juniper/MX-series/telemetry_gnmi.conf
@@ -1,4 +1,15 @@
+/* This method is insecure and should only be used in a lab. */
 set system services extension-service request-response grpc clear-text address {{local_address}}
 set system services extension-service request-response grpc clear-text port {{local_port}}
 set system services extension-service notification allow-clients address {{kentik_agent_IP}}
 set system schema openconfig unhide
+
+/* This method uses SSL with a self-signed cerficate for production environments.
+Upload an x509 certificate to the router or create a self-signed certificate. For example, on any Linux machine:
+$ openssl req -x509 -sha256 -nodes -newkey rsa:2048 -keyout grpc-cert.pem -out grpc-cert.pem
+*/
+set security certificates local grpc-cert load-key-file grpc-cert.pem
+set system services extension-service request-response grpc ssl address {{local_address}}
+set system services extension-service request-response grpc ssl port {{local_port}}
+set system services extension-service request-response grpc ssl local-certificate grpc-cert
+set system services extension-service notification allow-clients address {{kentik_agent_IP}}

--- a/Juniper/MX-series/telemetry_gnmi.conf
+++ b/Juniper/MX-series/telemetry_gnmi.conf
@@ -1,4 +1,4 @@
-set system services extension-service request-response grpc clear-text address {{device_sending_ip}}
-set system services extension-service request-response grpc clear-text port {{device_listening_port}}
+set system services extension-service request-response grpc clear-text address {{local_address}}
+set system services extension-service request-response grpc clear-text port {{local_port}}
 set system services extension-service notification allow-clients address {{kentik_agent_IP}}
 set system schema openconfig unhide

--- a/Juniper/MX-series/telemetry_gnmi.conf
+++ b/Juniper/MX-series/telemetry_gnmi.conf
@@ -1,0 +1,4 @@
+set system services extension-service request-response grpc clear-text address {{device_sending_ip}}
+set system services extension-service request-response grpc clear-text port {{device_listening_port}}
+set system services extension-service notification allow-clients address {{kentik_agent_IP}}
+set system schema openconfig unhide

--- a/Juniper/MX-series/telemetry_native-agent.conf
+++ b/Juniper/MX-series/telemetry_native-agent.conf
@@ -3,15 +3,15 @@ services {
     analytics {
         streaming-server KENTIK-REMOTE {
             # remote-address - IP of the Kentik Flow Proxy Agent
-            remote-address <kentik_flow_proxy_agent_IP>;
+            remote-address {{kentik_flow_proxy_agent_IP}};
             # remote-port - port of the Kentik Flow Proxy Agent
-            remote-port <ipfix_port_default_9555_with_agent>;
+            remote-port {{ipfix_port_default_9555_with_agent}};
         }
         export-profile KENTIK-PROF {
             # IP of interface that will be source of telemety records.
-            local-address <local-address>;
+            local-address {{local-address}};
             # local port will be source of telemery records.
-            local-port <local-port>;
+            local-port {{local-port}};
             reporting-rate 30;
             format gpb;
             transport udp;

--- a/Juniper/MX-series/telemetry_native.conf
+++ b/Juniper/MX-series/telemetry_native.conf
@@ -9,9 +9,9 @@ services {
         }
         export-profile KENTIK-PROF {
             # IP of interface that will be source of telemety records.
-            local-address <local-address>;
+            local-address {{local_address}};
             # local port will be source of telemery records.
-            local-port <local-port>;
+            local-port {{local_port}};
             reporting-rate 30;
             format gpb;
             transport udp;


### PR DESCRIPTION
Added in dial-in (gNMI) configs for Juniper Streaming Telemetry and fixed a couple variables in the dial-out configs.