### PR TITLE
Update snmp-agent.conf

### DIFF
--- a/Huawei/snmp-agent.conf
+++ b/Huawei/snmp-agent.conf
@@ -6,4 +6,5 @@ snmmp-agent acl <ACL_number_used_for_KENTIK_SNMP_POLLING>
 # use cipher to encrypt name when displaying current config
 snmp-agent community read cipher <SNMP_Community_String_for_KENTIK>
 snmp-agent sys-info version v2c
-
+# persist all interface indexes
+snmp-agent ifindex constant


### PR DESCRIPTION
Adding Huawei specific index persistence so that reboots and changing out cards (etc) doesn't scramble the list of existing interface indexes.

Documentation found here - https://support.huawei.com/enterprise/en/doc/EDOC1000017276/7eca3ea/optional-configuring-the-constant-interface-index-feature 