### PR TITLE
fixing sflow agent-id to not point to KentikUI

### DIFF
--- a/Juniper/QFX_EX-series/sflow-agent.conf
+++ b/Juniper/QFX_EX-series/sflow-agent.conf
@@ -1,7 +1,7 @@
 protocols {
     sflow {
-        agent-id {{kentik_flow_proxy_IP}};
-        polling-interval 0;
+        agent-id {{device_sending_ip}};
+        polling-interval 60;
         sample-rate ingress {{device_sample_rate}};
         source-ip {{device_sending_ip}};
         # collector sends to your Kentik Flow Proxy aka KPROXY

--- a/Juniper/QFX_EX-series/sflow-agent.conf
+++ b/Juniper/QFX_EX-series/sflow-agent.conf
@@ -1,7 +1,7 @@
 protocols {
     sflow {
         agent-id {{device_sending_ip}};
-        polling-interval 60;
+        polling-interval 0;
         sample-rate ingress {{device_sample_rate}};
         source-ip {{device_sending_ip}};
         # collector sends to your Kentik Flow Proxy aka KPROXY

--- a/Juniper/QFX_EX-series/sflow.conf
+++ b/Juniper/QFX_EX-series/sflow.conf
@@ -1,6 +1,6 @@
 protocols {
     sflow {
-        agent-id {{kentik_ingest_ip_from_UI}};
+        agent-id {{device_sending_ip}};
         polling-interval 0;
         sample-rate ingress {{device_sample_rate}};
         source-ip {{device_sending_ip}};


### PR DESCRIPTION
Could have the option to include loopback but I think sending IP here is sufficient