### PR TITLE
Juniper Streaming Telemetry Comment Updates

### DIFF
--- a/Juniper/MX-series/telemetry_dialin.conf
+++ b/Juniper/MX-series/telemetry_dialin.conf
@@ -52,7 +52,11 @@ system {
 
 /* This method uses SSL with a self-signed cerficate for production environments.
 Upload an x509 certificate to the router or create a self-signed certificate. For example, on any Linux machine:
-$ openssl req -x509 -sha256 -nodes -newkey rsa:2048 -keyout grpc-cert.pem -out grpc-cert.pem
+$ openssl req -x509 -sha256 -nodes -newkey rsa:2048 -keyout grpc-cert.key -out grpc-cert.pem
+
+You can also generate a self-signed certificate directly from the JUNOS CLI:
+Generate keypair: > request security pki generate-key-pair size 2048 type rsa certificate-id grpc-cert
+Generate certificate: > request security pki local-certificate generate-self-signed certificate-id grpc-cert domain-name <FQDN> email <Email> subject CN=<FQDN>,OU=<Organizational-Unit-name>,O=<Organization-name>,L=<Locality>,ST=<state>,C=<Country>
 */
 set security certificates local grpc-cert load-key-file grpc-cert.pem
 


### PR DESCRIPTION
This pull request updates the instructions for generating SSL certificates in the `telemetry_dialin.conf` file for Juniper MX-series routers. It corrects a file naming inconsistency and adds an alternative method for generating self-signed certificates directly from the JUNOS CLI.

Certificate generation updates:

* Updated the OpenSSL command to correctly name the private key file as `grpc-cert.key` instead of `grpc-cert.pem` for clarity and consistency.
* Added detailed instructions for generating a self-signed certificate directly from the JUNOS CLI, including commands for creating a key pair and generating the certificate with custom attributes.