### PR TITLE
updates for iosxr based on recent customer config

### DIFF
--- a/Arista/sflow-agent.conf
+++ b/Arista/sflow-agent.conf
@@ -8,7 +8,8 @@ sflow source-interface <interface_name>
 ! other option is to direclty point to a source IP configured on the device
 sflow source {{device_sending_ip}}
 
-sflow polling-interval 10
+! kentik ignores sflow counters so we can set this to zero
+sflow polling-interval 0
 
 ! Set sample rate based on flow volume.
 sflow sample {{device_sample_rate}}

--- a/Arista/sflow.conf
+++ b/Arista/sflow.conf
@@ -6,7 +6,8 @@ sflow source-interface <interface_name>
 ! other option is to direclty point to a source IP configured on the device
 sflow source {{device_sending_ip}}
 
-sflow polling-interval 10
+! kentik ignores sflow counters so we can set this to zero
+sflow polling-interval 0
 
 ! Set sample rate based on flow volume.
 sflow sample {{device_sample_rate}}

--- a/Cisco/IOS-XR/sflow-agent.conf
+++ b/Cisco/IOS-XR/sflow-agent.conf
@@ -1,0 +1,22 @@
+! sflow IOS-XR
+!
+feature sflow
+!
+! Set sample rate based on flow volume.
+sflow sampling-rate {{device_sample_rate}}
+! size of headers we intend to sample to catch multiple encapsulations
+sflow max-sampled-size 200
+! kentik ignores sflow counters so we can set this to zero
+sflow counter-poll-interval 0
+! maximum number of data bytes that can be sent in a single sample datagram. internet < 1500 bytes
+sflow max-datagram-size 1400
+!
+! Export to Kentik Flow Proxy
+sflow collector-ip {{kentik_flow_proxy_IP}}
+sflow collector-port 9995
+!
+! sFlow agent address to enable sFlow functionality on the device
+! this can be any IP address configured on the device such as the loopback
+sflow agent-ip {{ loopback-ip }}
+! the IP address or source interface from which the device will source sflow packets from
+sflow data-source interface {{ source-interface }}

--- a/Cisco/IOS-XR/sflow.conf
+++ b/Cisco/IOS-XR/sflow.conf
@@ -1,4 +1,4 @@
-! SNMP IOS-XR
+! sflow IOS-XR
 !
 feature sflow
 !

--- a/Cisco/IOS-XR/sflow.conf
+++ b/Cisco/IOS-XR/sflow.conf
@@ -9,7 +9,7 @@ sflow max-sampled-size 200
 ! kentik ignores sflow counters so we can set this to zero
 sflow counter-poll-interval 0
 ! maximum number of data bytes that can be sent in a single sample datagram. internet < 1500 bytes
-sflow max-datagram-size 1350
+sflow max-datagram-size 1400
 !
 ! Kentik specific endpoints to receive sflow
 sflow collector-ip {{kentik_ingest_ip_from_UI}}

--- a/Cisco/IOS-XR/sflow.conf
+++ b/Cisco/IOS-XR/sflow.conf
@@ -1,0 +1,22 @@
+! SNMP IOS-XR
+!
+feature sflow
+!
+! Set sample rate based on flow volume.
+sflow sampling-rate {{device_sample_rate}}
+! size of headers we intend to sample to catch multiple encapsulations
+sflow max-sampled-size 200
+! kentik ignores sflow counters so we can set this to zero
+sflow counter-poll-interval 0
+! maximum number of data bytes that can be sent in a single sample datagram. internet < 1500 bytes
+sflow max-datagram-size 1350
+!
+! Kentik specific endpoints to receive sflow
+sflow collector-ip {{kentik_ingest_ip_from_UI}}
+sflow collector-port {{kentik_ingest_UDP_port_from_UI}}
+!
+! sFlow agent address to enable sFlow functionality on the device
+! this can be any IP address configured on the device such as the loopback
+sflow agent-ip {{ loopback-ip }}
+! the IP address or source interface from which the device will source sflow packets from
+sflow data-source interface {{ source-interface }}

--- a/Cisco/Nexus-3000/sflow.conf
+++ b/Cisco/Nexus-3000/sflow.conf
@@ -9,7 +9,7 @@ sflow max-sampled-size 200
 sflow counter-poll-interval 0
 
 ! maximum number of data bytes that can be sent in a single sample datagram. internet < 1500 bytes
-sflow max-datagram-size 1350
+sflow max-datagram-size 1400
 
 ! Destination is Kentik public Flow Ingest (not Flow Proxy Agent)
 sflow collector-ip {{kentik_ingest_ip_from_UI}} vrf management

--- a/Cisco/Nexus-3000/sflow.conf
+++ b/Cisco/Nexus-3000/sflow.conf
@@ -4,8 +4,12 @@ feature sflow
 ! Set sample rate based on flow volume.
 sflow sampling-rate {{device_sample_rate}}
 sflow max-sampled-size 200
-sflow counter-poll-interval 100
-sflow max-datagram-size 2000
+
+! kentik ignores sflow counters so we can set this to zero
+sflow counter-poll-interval 0
+
+! maximum number of data bytes that can be sent in a single sample datagram. internet < 1500 bytes
+sflow max-datagram-size 1350
 
 ! Destination is Kentik public Flow Ingest (not Flow Proxy Agent)
 sflow collector-ip {{kentik_ingest_ip_from_UI}} vrf management


### PR DESCRIPTION
- adding sflow config for IOS-XR based on customer configuration.
- updating NXOS3k configuration with small updates to disable counters and modify [max-datagram-size](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus3000/sw/system_mgmt/7_x/b_Cisco_Nexus_3000_Series_NX-OS_System_Management_Configuration_Guide_7x/b_Cisco_Nexus_3000_Series_NX-OS_System_Management_Configuration_Guide_7x_chapter_010110.html) per defaults to accommodate expected 1500 byte internet size restrictions.
- update to Arista sflow polling interval to zero (don't send counters by default)
