### PR TITLE
Update netflow-9.conf with template timeout settings

### DIFF
--- a/Cisco/IOS-XE/netflow-9.conf
+++ b/Cisco/IOS-XE/netflow-9.conf
@@ -27,6 +27,8 @@ flow exporter <KENTIK-EXPORT>
     destination {{kentik_ingest_ip_from_UI}} vrf <vrf_name_if_used>
     source <netflow_source_interface_name>
     transport udp {{kentik_ingest_UDP_port_from_UI}}
+    ! This can be configurred to refresh templates between 1-86400 seconds. If using HA failover, set to 5 seconds. 
+    template data timeout 60
     version 9
 !
 !

--- a/Cisco/IOS-XE/netflow-9.conf
+++ b/Cisco/IOS-XE/netflow-9.conf
@@ -27,7 +27,7 @@ flow exporter <KENTIK-EXPORT>
     destination {{kentik_ingest_ip_from_UI}} vrf <vrf_name_if_used>
     source <netflow_source_interface_name>
     transport udp {{kentik_ingest_UDP_port_from_UI}}
-    ! This can be configurred to refresh templates between 1-86400 seconds. If using HA failover, set to 5 seconds. 
+    ! This can be configured to refresh templates between 1-86400 seconds. If using HA failover, set to 5 seconds.
     template data timeout 60
     version 9
 !


### PR DESCRIPTION
Added a comment regarding template refresh configuration and set template data timeout to 60 seconds.